### PR TITLE
Fix writings article link

### DIFF
--- a/src/writings/index.njk
+++ b/src/writings/index.njk
@@ -15,7 +15,7 @@ description: Essays and short-form writing by Richard Caballero.
     {% for post in collections.writings | reverse %}
       <li>
         <article>
-          <h3><a href="{{ post.url }}">{{ post.data.title }}</a></h3>
+          <h3><a href="{{ post.url | url }}">{{ post.data.title }}</a></h3>
           <p class="meta">{{ post.data.date | formatDate }} · {{ post.data.form }}</p>
           {% if post.data.summary %}
             <p>{{ post.data.summary }}</p>


### PR DESCRIPTION
Summary
- align the writings article links with the published path so the deep link no longer 404s
- ensure configuration updates match the published site structure after the recent merge

Testing
- Not run (not requested)