### PR TITLE
Fix FOUC, nav state, dead code, and sync script safety

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,5 +1,5 @@
 module.exports = function (eleventyConfig) {
-  var pathPrefix = process.env.ELEVENTY_PATH_PREFIX || "/";
+  var pathPrefix = "/";
 
   eleventyConfig.addPassthroughCopy({ "src/assets": "assets" });
   eleventyConfig.addPassthroughCopy({

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "description": "Eleventy prototype for Richard Caballero portfolio",
   "scripts": {
-    "dev": "ELEVENTY_PATH_PREFIX=/ eleventy --serve --input=src --output=dist",
-    "build": "ELEVENTY_PATH_PREFIX=/ eleventy --input=src --output=dist",
+    "dev": "eleventy --serve --input=src --output=dist",
+    "build": "eleventy --input=src --output=dist",
     "sync:writings": "./scripts/sync-obsidian-writings.sh"
   },
   "devDependencies": {

--- a/scripts/sync-obsidian-writings.sh
+++ b/scripts/sync-obsidian-writings.sh
@@ -22,6 +22,15 @@ fi
 
 mkdir -p "$TARGET_DIR"
 
+# Abort if source has no markdown files to avoid wiping essays on an empty or wrong path.
+if [[ -z "$(find "$SOURCE_DIR" -maxdepth 1 -type f -name "*.md")" ]]; then
+  echo
+  echo "No markdown files found in:"
+  echo "  $SOURCE_DIR"
+  echo "Nothing was changed."
+  exit 1
+fi
+
 # Sync published markdown files only. Keep the Eleventy index template in place.
 find "$TARGET_DIR" -maxdepth 1 -type f -name "*.md" -delete
 

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -10,13 +10,12 @@
     <meta name="apple-mobile-web-app-title" content="{{ site.title }}">
     <meta name="apple-mobile-web-app-status-bar-style" content="{{ site.theme.appleStatusBarStyle }}">
     <link rel="icon" href="{{ '/favicon.ico' | url }}?v=2" sizes="any">
-    <link rel="shortcut icon" href="{{ '/favicon.ico' | url }}?v=2">
     <link rel="icon" type="image/svg+xml" href="{{ '/assets/favicon/favicon.svg' | url }}?v=2">
     <link rel="icon" type="image/png" sizes="96x96" href="{{ '/assets/favicon/favicon-96x96.png' | url }}?v=2">
     <link rel="apple-touch-icon" href="{{ '/assets/favicon/apple-touch-icon.png' | url }}">
     <link rel="manifest" href="{{ '/assets/favicon/site.webmanifest' | url }}">
     <link rel="stylesheet" href="{{ '/assets/style.css' | url }}">
-    <script src="{{ '/assets/theme.js' | url }}" defer></script>
+    <script src="{{ '/assets/theme.js' | url }}"></script>
   </head>
   <body>
     <header class="site-header">
@@ -24,7 +23,7 @@
         <a class="brand" href="{{ '/' | url }}">{{ site.title }}</a>
         <nav class="site-nav" aria-label="Primary">
           <a href="{{ '/' | url }}" {% if page.url == "/" %}aria-current="page"{% endif %}>Home</a>
-          <a href="{{ '/writings/' | url }}" {% if page.url == "/writings/" %}aria-current="page"{% endif %}>Writings</a>
+          <a href="{{ '/writings/' | url }}" {% if page.url.startsWith("/writings/") %}aria-current="page"{% endif %}>Writings</a>
           <label class="theme-switch" aria-label="Toggle color theme">
             <input id="theme-toggle" type="checkbox" role="switch" aria-label="Theme toggle">
             <span class="slider" aria-hidden="true"></span>

--- a/src/_includes/layouts/writing.njk
+++ b/src/_includes/layouts/writing.njk
@@ -1,7 +1,7 @@
 ---
 layout: layouts/base.njk
 ---
-<article class="essay">
+<article>
   <header class="essay-header">
     <h1>{{ title }}</h1>
     <p class="meta">{{ date | formatDate }}{% if form %} · {{ form }}{% endif %}</p>

--- a/src/writings/index.njk
+++ b/src/writings/index.njk
@@ -11,17 +11,21 @@ description: Essays and short-form writing by Richard Caballero.
 </section>
 
 <section>
-  <ul class="list">
-    {% for post in collections.writings | reverse %}
-      <li>
-        <article>
-          <h3><a href="{{ post.url | url }}">{{ post.data.title }}</a></h3>
-          <p class="meta">{{ post.data.date | formatDate }} · {{ post.data.form }}</p>
-          {% if post.data.summary %}
-            <p>{{ post.data.summary }}</p>
-          {% endif %}
-        </article>
-      </li>
-    {% endfor %}
-  </ul>
+  {% if collections.writings and collections.writings.length %}
+    <ul class="list">
+      {% for post in collections.writings | reverse %}
+        <li>
+          <article>
+            <h3><a href="{{ post.url | url }}">{{ post.data.title }}</a></h3>
+            <p class="meta">{{ post.data.date | formatDate }} · {{ post.data.form }}</p>
+            {% if post.data.summary %}
+              <p>{{ post.data.summary }}</p>
+            {% endif %}
+          </article>
+        </li>
+      {% endfor %}
+    </ul>
+  {% else %}
+    <p class="lead">No writings published yet.</p>
+  {% endif %}
 </section>


### PR DESCRIPTION
- Remove defer from theme script to prevent flash on sepia mode load
- Fix aria-current to activate Writings nav on all /writings/ sub-pages
- Remove unused .essay class from article wrapper in writing layout
- Remove legacy shortcut icon link tag from base layout
- Guard sync script against wiping essays when source folder is empty
- Hardcode pathPrefix to "/" and remove redundant ELEVENTY_PATH_PREFIX env var